### PR TITLE
Refs #10970 - Fixing label validator on kt_environment

### DIFF
--- a/app/models/katello/kt_environment.rb
+++ b/app/models/katello/kt_environment.rb
@@ -50,8 +50,9 @@ module Katello
                      :exclusion => { :in => ["Library"], :message => N_(": '%s' is a built-in environment") % "Library", :unless => :library? }
     validates :label, :presence => true, :uniqueness => {:scope => :organization_id,
                                                          :message => N_("of environment must be unique within one organization")},
-                      :exclusion => { :in => ["Library"], :message => N_(": '%s' is a built-in environment") % "Library", :unless => :library?},
-                      :exclusion => { :in => [ContentView::CONTENT_DIR], :message => N_(": '%s' is a built-in environment") % ContentView::CONTENT_DIR }
+                      :exclusion => { :in => ["Library"], :message => N_(": '%s' is a built-in environment") % "Library", :unless => :library? }
+    validates_exclusion_of :label, :in => [ContentView::CONTENT_DIR], :message => N_(": '%s' is a built-in environment") % ContentView::CONTENT_DIR
+
     validates_with Validators::KatelloNameFormatValidator, :attributes => :name
     validates_with Validators::KatelloLabelFormatValidator, :attributes => :label
     validates_with Validators::PriorValidator

--- a/test/models/kt_environment_test.rb
+++ b/test/models/kt_environment_test.rb
@@ -61,12 +61,20 @@ module Katello
       assert_operator @library.repositories.map(&:product).length, :>, @library.products.length
     end
 
-    def test_content_view_label
+    def test_content_view_label_excludes_library
+      env = @acme_corporation.kt_environments.build(:name => "Test", :label => "Library",
+                                                    :prior => @library)
+      refute env.save
+      assert_equal 1, env.errors.size
+      assert env.errors.key?(:label)
+    end
+
+    def test_content_view_label_excludes_content_dir
       env = @acme_corporation.kt_environments.build(:name => "Test", :label => ContentView::CONTENT_DIR,
                                                     :prior => @library)
       refute env.save
       assert_equal 1, env.errors.size
-      assert env.errors.has_key?(:label) # rubocop:disable Style/DeprecatedHashMethods
+      assert env.errors.key?(:label)
     end
   end
 end


### PR DESCRIPTION
Declaring a key a second time in a validator overrides the first.
Updating to exclude both "Library" and ContentView::CONTENT_DIR
