### PR TITLE
Refs #10970 - Fix actions katello host register

### DIFF
--- a/app/lib/actions/katello/host/register.rb
+++ b/app/lib/actions/katello/host/register.rb
@@ -108,8 +108,9 @@ module Actions
           subscription_facet = host.subscription_facet || ::Katello::Host::SubscriptionFacet.new
           subscription_facet.host = host
           subscription_facet.update_from_consumer_attributes(consumer_params)
-          subscription_facet.save!
+          subscription_facet.save! # persist to obtain an id
           subscription_facet.activation_keys = activation_keys
+          subscription_facet.save!
           subscription_facet
         end
       end

--- a/test/actions/katello/host/register_test.rb
+++ b/test/actions/katello/host/register_test.rb
@@ -53,7 +53,10 @@ module Katello::Host
         action = create_action action_class
         new_host = Host::Managed.new(:name => 'foobar', :managed => false)
         action.stubs(:action_subject).with(new_host)
-        plan_action action, new_host, new_system, rhsm_params, nil, [@activation_key]
+
+        activation_keys = []
+        activation_keys << @activation_key
+        plan_action action, new_host, new_system, rhsm_params, nil, activation_keys
 
         assert_action_planed_with(action, candlepin_class, :cp_environment_id => cvpe.cp_id,
                                   :consumer_parameters => rhsm_params, :activation_keys => [@activation_key.cp_name])


### PR DESCRIPTION
The plan_subscription_facet method was not persisting the associated
activation_keys.
