### PR TITLE
Refs #10970 - Updates tests to set default location when needed

### DIFF
--- a/test/actions/katello/content_view_puppet_environment_test.rb
+++ b/test/actions/katello/content_view_puppet_environment_test.rb
@@ -8,6 +8,10 @@ module ::Actions::Katello::ContentViewPuppetEnvironment
     include Support::CapsuleSupport
 
     let(:puppet_env) { katello_content_view_puppet_environments(:library_view_puppet_environment) }
+
+    setup do
+      set_default_location
+    end
   end
 
   class CreateTest < TestBase

--- a/test/katello_test_helper.rb
+++ b/test/katello_test_helper.rb
@@ -70,9 +70,6 @@ module FixtureTestCase
 
     @@admin = ::User.find(FIXTURES['users']['admin']['id'])
     User.current = @@admin
-    loc = Location.first
-    loc.katello_default = true
-    loc.save!
   end
 end
 
@@ -200,6 +197,12 @@ class ActiveSupport::TestCase
     cp_consumer_user.uuid = uuid
     cp_consumer_user.login = uuid
     User.stubs(:current).returns(cp_consumer_user)
+  end
+
+  def set_default_location
+    loc = Location.first
+    loc.katello_default = true
+    loc.save!
   end
 end
 

--- a/test/models/concerns/environment_extensions_test.rb
+++ b/test/models/concerns/environment_extensions_test.rb
@@ -6,6 +6,7 @@ module Katello
   class EnvironmentExtensionsTest < ActiveSupport::TestCase
     def setup
       User.current = User.find(users(:admin))
+      set_default_location
       @katello_id = "KT_Org_Env_View_1"
 
       @org = get_organization

--- a/test/models/foreman/location_test.rb
+++ b/test/models/foreman/location_test.rb
@@ -2,6 +2,10 @@ require 'katello_test_helper'
 
 module Katello
   class LocationTest < ActiveSupport::TestCase
+    def setup
+      set_default_location
+    end
+
     def test_location_create
       loc = Location.create!(:name => "FOO")
       assert_includes loc.ignore_types, ::ProvisioningTemplate.name


### PR DESCRIPTION
Explicitly set default location on tests instead of setting for each test. This fixes content view puppet environment test failure.
