### PR TITLE
Refs #10970 - adding attr_accessible back to foreman extensions

### DIFF
--- a/app/models/katello/concerns/container_extensions.rb
+++ b/app/models/katello/concerns/container_extensions.rb
@@ -6,6 +6,7 @@ module Katello
       included do
         belongs_to :capsule, :inverse_of => :containers, :foreign_key => :capsule_id,
           :class_name => "SmartProxy"
+        attr_accessible :capsule_id
 
         alias_method_chain :repository_pull_url, :katello
       end

--- a/app/models/katello/concerns/smart_proxy_extensions.rb
+++ b/app/models/katello/concerns/smart_proxy_extensions.rb
@@ -12,6 +12,7 @@ module Katello
         before_create :associate_default_location
         before_create :associate_lifecycle_environments
         before_create :associate_content_host
+        attr_accessible :lifecycle_environment_ids
 
         has_many :containers,
                  :class_name => "Container",


### PR DESCRIPTION
adding attr_accessible back to foreman extensions as they are still needed. Foreman is using protected_attributes in their rails 4 changes.
