### PR TITLE
Refs #10970 - Fixing katello url helper compatability

### DIFF
--- a/app/helpers/katello/katello_url_helper.rb
+++ b/app/helpers/katello/katello_url_helper.rb
@@ -1,27 +1,19 @@
 module Katello
   module KatelloUrlHelper
     unless defined? CONSTANTS_DEFINED
-      FILEPREFIX = 'file'
-      PROTOCOLS = ['http', 'https', 'ftp', FILEPREFIX]
+      FILEPREFIX = ['file']
+      PROTOCOLS = ['http', 'https', 'ftp']
 
       CONSTANTS_DEFINED = true
     end
 
     def kurl_valid?(url)
-      valid_for_prefixes(url, PROTOCOLS)
-    end
-
-    def file_prefix?(url)
-      valid_for_prefixes(url, [FILEPREFIX])
-    end
-
-    private
-
-    def valid_for_prefixes(url, prefixes)
-      return false unless (scheme = URI.parse(url).scheme).present?
-      prefixes.include?(scheme.downcase)
+      return false if (scheme = URI.parse(url).scheme).blank?
+      return true if FILEPREFIX.include?(scheme.downcase)
+      URI.parse(url).host.present? && PROTOCOLS.include?(scheme.downcase)
     rescue URI::InvalidURIError
       return false
     end
+
   end
 end

--- a/spec/helpers/katello_url_helper_spec.rb
+++ b/spec/helpers/katello_url_helper_spec.rb
@@ -37,18 +37,15 @@ module Katello
       it "should validate file urls" do
         kurl_valid?('file://opt/repo').must_equal(true)
         kurl_valid?('/opt/repo').must_equal(false)
-      end
-
-      it "should validate file urls" do
         kurl_valid?('file://opt/repo-is-long/').must_equal(true)
         kurl_valid?('/opt/repo-for-me').must_equal(false)
       end
 
       it "should validate file urls with multiple slashes" do
-        file_prefix?('file://///opt/repo').must_equal(true)
+        kurl_valid?('file://///opt/repo').must_equal(true)
         kurl_valid?('file://///opt/').must_equal(true)
         kurl_valid?('File://///opt/').must_equal(true)
-        file_prefix?('/////opt/repo').must_equal(false)
+        kurl_valid?('/////opt/repo').must_equal(false)
         kurl_valid?('/////opt/repo').must_equal(false)
       end
 


### PR DESCRIPTION
This fix makes the katello url helper compatable with all currently
supported versions of ruby. 1.9.3, 2.0.x, 2.1.x, 2.2.x
